### PR TITLE
Fix hello world typo

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 export function init() {
-  return 'Hello, Word!'
+  return 'Hello, World!'
 }
 
 export default init


### PR DESCRIPTION
Someone changed `'Hello, World!'` to `'Hello, Word!'` >:(

This PR fixes failing tests.