### PR TITLE
Add `greet()` function and tests

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,4 +2,8 @@ export function init() {
   return 'Hello, Word!'
 }
 
+export function greet(name) {
+  return `Hello, ${name}!`
+}
+
 export default init

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,5 +1,13 @@
-import { init } from '../src'
+import Default, { init, greet } from '../src'
 
 test('Hello, World!', () => {
   expect(init()).toBe('Hello, World!')
+})
+
+test.each(['Alice', 'Bob', 'Cameron'])('Hello, %s!', (name) => {
+  expect(greet(name)).toBe(`Hello, ${name}!`)
+})
+
+test('default export', () => {
+  expect(Default()).toBe(init())
 })


### PR DESCRIPTION
Added `greet()` with tests, and a test to ensure `init()` is the default export.